### PR TITLE
feat(RuleSchema): add matchSchema and deleteSchema methods

### DIFF
--- a/src/RuleSchema.php
+++ b/src/RuleSchema.php
@@ -169,4 +169,18 @@ class RuleSchema implements RuleSchemaInterface
 
         return $this;
     }
+
+    public function matchSchema(array $methods=["put","patch"],Rule ...$rules): self
+    {
+        $this->when(in_array(Request::method(),$methods), ...$rules);
+
+        return $this;
+    }
+
+    public function deleteSchema(Rule ...$rules): self
+    {
+        $this->when(Request::isMethod('DELETE'), ...$rules);
+
+        return $this;
+    }
 }


### PR DESCRIPTION
Adds two new methods to the RuleSchema class:
- `matchSchema()` which applies a set of rules when the HTTP method
  matches the provided list of methods (default is `PUT` and `PATCH`)
- `deleteSchema()` which applies a set of rules when the HTTP method
  is `DELETE`

These new methods provide a more concise way to apply rules based on
the HTTP method, improving the overall usability and flexibility of
the RuleSchema class.